### PR TITLE
Getting the domain for the hostname was broken on single domain (worked on multiple domain only)

### DIFF
--- a/scripts/commons
+++ b/scripts/commons
@@ -2,7 +2,7 @@
 
 # Fix hostname and configure hosts
 set_correct_hostname() {
-    domain=$(sudo yunohost domain list | sed -n '2p' | sed 's/  - //')
+    domain=$(cat /etc/yunohost/current_host)
     if [ -n "$domain" ] && ! hostnamectl --static | grep -q '\.'; then
         sudo hostnamectl --static set-hostname "${domain}"
         sudo hostnamectl --transient set-hostname "${domain}"

--- a/scripts/commons
+++ b/scripts/commons
@@ -6,7 +6,7 @@ set_correct_hostname() {
     if [ -n "$domain" ] && ! hostnamectl --static | grep -q '\.'; then
         sudo hostnamectl --static set-hostname "${domain}"
         sudo hostnamectl --transient set-hostname "${domain}"
-        sudo hostnamectl --pretty set-hostname "La Brique InterNet (${domain})"
+        sudo hostnamectl --pretty set-hostname "La Brique Internet (${domain})"
 
         if ! grep -q "127.0.0.1 ${domain}" /etc/hosts; then
             echo "127.0.0.1 $domain" | sudo tee -a /etc/hosts

--- a/scripts/install
+++ b/scripts/install
@@ -8,7 +8,7 @@ export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
 export LC_ALL=C LANGUAGE=C LANG=C
 apt='sudo --preserve-env apt-get'
 
-sudo yunohost app setting doctorcube version -v "0.2"
+sudo yunohost app setting doctorcube version -v "0.2.1"
 sudo yunohost app fetchlist -n labriqueinternet -u https://labriqueinter.net/apps/labriqueinternet.json
 
 if [ "$(find /boot/ -name '*olinux*')" ]; then

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -6,11 +6,24 @@ source ./commons
 
 version=$(sudo yunohost app setting doctorcube version)
 
-# 0.1 -> 0.2
+# 0.1 -> 0.2.1
 if [[ "$version" == "0.1" ]]; then
 
     set_correct_hostname
 
-    sudo yunohost app setting doctorcube version -v "0.2"
-    version="0.2"
+    sudo yunohost app setting doctorcube version -v "0.2.1"
+    version="0.2.1"
+fi
+
+# 0.2 -> 0.2.1
+if [[ "$version" == "0.2" ]]; then
+
+    # we weren't setting the domain correctly in the case of only
+    # one single domain
+    if [[ "$(hostname)" == "olinux" ]]; then
+        set_correct_hostname
+    fi
+
+    sudo yunohost app setting doctorcube version -v "0.2.1"
+    version="0.2.1"
 fi


### PR DESCRIPTION
As discusted with @jvaubourg.

This new method will work in all situations and will also get the current default domain.
